### PR TITLE
Fixed Q library require having wrong casing

### DIFF
--- a/bin/pastebin.js
+++ b/bin/pastebin.js
@@ -1,7 +1,7 @@
 var _ = require('underscore'),
     fs = require('fs'),
     xml2js = require('xml2js'),
-    Q = require('Q'),
+    Q = require('q'),
     method = require('../lib/methods'),
     conf = require('../lib/config');
 

--- a/lib/methods.js
+++ b/lib/methods.js
@@ -1,6 +1,6 @@
 var request = require('request'),
     config = require('./config'),
-    Q = require('Q'),
+    Q = require('q'),
     TIMEOUT = 4000,
     HEADERS = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Safari/537.36',


### PR DESCRIPTION
On case insensitive systems, an error was generated because module 'Q' could
not be found. Changed Q to lowercase
