### PR TITLE
Fixed issue with headers being invalid on newer node versions - Issue/9

### DIFF
--- a/lib/methods.js
+++ b/lib/methods.js
@@ -11,10 +11,16 @@ var config = require('./config');
 var pkg = require('../package');
 var Q = require('q');
 var TIMEOUT = 4000;
-var HEADERS = {
-    'User-Agent': 'Pastebin-js/' + pkg.version,
-    'Cache-Control:' : 'no-cache'
-};
+var HEADERS = [
+    {
+        name: 'User-Agent',
+        value: 'Pastebin-js/' + pkg.version,
+    },
+    {
+        name: 'Cache-Control',
+        value: 'no-cache'
+    }
+];
 
 var methods = module.exports = {
     get : function (path, params) {


### PR DESCRIPTION
#9 

http://stackoverflow.com/questions/33596103/nodejs-http-outgoing-crash-with-pastebin-api