### PR TITLE
fixed .length issue

### DIFF
--- a/lib/methods.js
+++ b/lib/methods.js
@@ -54,6 +54,7 @@ var methods = module.exports = {
             }
             if (!body || body.length === 0) {
                 deferred.reject(new Error('Empty response'));
+                return
             }
             if (body.indexOf('Bad API request') !== -1) {
                 deferred.reject(new Error(body));

--- a/lib/methods.js
+++ b/lib/methods.js
@@ -52,7 +52,7 @@ var methods = module.exports = {
             if (status !== 200) {
                 deferred.reject(new Error('Unknown error, status: ' + status));
             }
-            if (body.length === 0) {
+            if (!body || body.length === 0) {
                 deferred.reject(new Error('Empty response'));
             }
             if (body.indexOf('Bad API request') !== -1) {


### PR DESCRIPTION
Been sometimes getting this issue. This would fix this up without causing TypeError and making the script exit.

TypeError: Cannot read property 'length' of undefined
    at Request._callback (/root/paste-reader/node_modules/pastebin-js/lib/methods.js:55:22)
    at self.callback (/root/paste-reader/node_modules/request/request.js:185:22)
    at Request.emit (events.js:182:13)
    at Request.EventEmitter.emit (domain.js:442:20)
    at Timeout._onTimeout (/root/paste-reader/node_modules/request/request.js:848:16)
    at ontimeout (timers.js:424:11)
    at tryOnTimeout (timers.js:288:5)
    at listOnTimeout (timers.js:251:5)
    at Timer.processTimers (timers.js:211:10)